### PR TITLE
Caleb explore

### DIFF
--- a/src/components/UI/NftCard.jsx
+++ b/src/components/UI/NftCard.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import Countdown from '../home/Countdown'
+
+function NftCard({item, index, likedArray, handleLikes}) {
+  return (
+    <div
+          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+          style={{ display: "block", backgroundSize: "cover" }}
+        >
+          <div className="nft__item">
+            <div className="author_list_pp">
+              <Link
+                to={`/author/${item.authorId}`}
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+              >
+                <img className="lazy" src={item.authorImage} alt="" />
+                <i className="fa fa-check"></i>
+              </Link>
+            </div>
+            <Countdown time={item.expiryDate} />
+
+            <div className="nft__item_wrap">
+              <div className="nft__item_extra">
+                <div className="nft__item_buttons">
+                  <button>Buy Now</button>
+                  <div className="nft__item_share">
+                    <h4>Share</h4>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-facebook fa-lg"></i>
+                    </a>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-twitter fa-lg"></i>
+                    </a>
+                    <a href="">
+                      <i className="fa fa-envelope fa-lg"></i>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <Link to={`/item-details/${item.nftId}`}>
+                <img src={item.nftImage} className="lazy nft__item_preview" alt="" />
+              </Link>
+            </div>
+            <div className="nft__item_info">
+              <Link to={`/item-details/${item.nftId}`}>
+                <h4>{item.title}</h4>
+              </Link>
+              <div className="nft__item_price">{item.price} ETH</div>
+              <div className="nft__item_like">
+              <i id={`likeButton${index}`} className="fa fa-heart" onClick={() => handleLikes(index)} />
+              <span>{(likedArray.some(value => value === index)) ? (item.likes + 1) : (item.likes)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+  )
+}
+
+export default NftCard

--- a/src/components/UI/NftCardSkeleton.jsx
+++ b/src/components/UI/NftCardSkeleton.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import Skeleton from './Skeleton'
+
+function NftCardSkeleton() {
+  return (
+    <div
+          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+          style={{ display: "block", backgroundSize: "cover" }}
+        >
+          <div className="nft__item">
+            <div className="author_list_pp">
+                <Skeleton width={'3rem'} height={"3rem"} borderRadius={'50%'}  />
+            </div>
+            <div className="nft__item_wrap">
+              <div className="nft__item_extra">
+                <div className="nft__item_buttons">
+                  <button>Buy Now</button>
+                  <div className="nft__item_share">
+                    <h4>Share</h4>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-facebook fa-lg"></i>
+                    </a>
+                    <a href="" target="_blank" rel="noreferrer">
+                      <i className="fa fa-twitter fa-lg"></i>
+                    </a>
+                    <a href="">
+                      <i className="fa fa-envelope fa-lg"></i>
+                    </a>
+                  </div>
+                </div>
+              </div>
+                <Skeleton height={'50%'} width={'100%'} borderRadius={'0'} />
+            </div>
+            <div className="nft__item_info w-100">
+                <div className="">
+                <div className="w-50 flex-column">
+                    <Skeleton height={'1rem'} width={'100%'} borderRadius={'0'} />
+                    <Skeleton height={'1rem'} width={'100%'} borderRadius={'0'} />
+                </div>
+                <div className="nft__item_like flex w-50 align-items-end skeleton-info-adjust">
+                    <i className="fa fa-heart mr-1" />
+                    <Skeleton height={'1rem'} width={'25%'} borderRadius={'0'} />
+                </div>
+                </div>
+            </div>
+          </div>
+        </div>
+  )
+}
+
+export default NftCardSkeleton

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,80 +1,99 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import NftCard from '../UI/NftCard'
+import NftCardSkeleton from '../UI/NftCardSkeleton'
 
 const ExploreItems = () => {
+  const [exploreData, setExploreData] = useState();
+  const [loading, setLoading] = useState(true);
+  const [apiString, setApiString] = useState('https://us-central1-nft-cloud-functions.cloudfunctions.net/explore')
+  const [shownItems, setShownItems] = useState(8);
+  const baseApiString = 'https://us-central1-nft-cloud-functions.cloudfunctions.net/explore'
+  useEffect(() => {
+    
+    window.scrollTo(0, 0);
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const result = await axios.get(apiString)
+        setExploreData(result.data)
+      } catch (error) {
+        console.log('[EXPLORE_PAGE_API_REQUEST_ERROR]: ', error) 
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData();
+
+  }, [apiString]);
+
+  const [likedArray, setLikedArray] = useState(new Array())
+
+  function handleLikes(index) {
+    const item = document.getElementById(`likeButton${index}`)
+    if (likedArray.some((value) => value === index)) {
+      setLikedArray(likedArray.filter((value) => value !== index))
+      item?.classList.remove('user-liked')
+    }
+    else {
+      setLikedArray([...likedArray, index])
+      item?.classList.add('user-liked')
+    }
+  }
+
+
+  if ( loading ) {
+    return (
+    <>
+      <div>
+        <select id="filter-items" disabled onChange={(e) => {setApiString(baseApiString + e.target.value); setShownItems(8)}} defaultValue="">
+          <option value="">Default</option>
+          <option value="?filter=price_low_to_high">Price, Low to High</option>
+          <option value="?filter=price_high_to_low">Price, High to Low</option>
+          <option value="?filter=likes_high_to_low">Most liked</option>
+        </select>
+      </div>
+      {
+        new Array(8).fill(0).map((_, index) => (
+            <NftCardSkeleton />
+        ))}
+        </>
+        )
+      
+    
+  }
+
   return (
     <>
       <div>
-        <select id="filter-items" defaultValue="">
+        <select id="filter-items" onChange={(e) => {setApiString(baseApiString + e.target.value); setShownItems(8)}} defaultValue="">
           <option value="">Default</option>
-          <option value="price_low_to_high">Price, Low to High</option>
-          <option value="price_high_to_low">Price, High to Low</option>
-          <option value="likes_high_to_low">Most liked</option>
+          <option value="?filter=price_low_to_high">Price, Low to High</option>
+          <option value="?filter=price_high_to_low">Price, High to Low</option>
+          <option value="?filter=likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
-            </div>
-            <div className="de_countdown">5h 30m 32s</div>
 
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
-            </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
-          </div>
+      {/* Grid container */}
+      {exploreData.map((item, index) => {
+        if (index < shownItems) {
+          return (
+            <NftCard key={item.id} item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
+          )
+        }
+      })}
+      {/* Load more button */}
+      {exploreData && exploreData.length > shownItems && (
+        <div className="col-md-12 text-center">
+          <button 
+            onClick={() => setShownItems(prev => prev + 4)}
+            className="btn-main lead"
+          >
+            Load More
+          </button>
         </div>
-      ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
-      </div>
+      )}
     </>
-  );
+  )
 };
-
-export default ExploreItems;
+  export default ExploreItems;

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useKeenSlider } from "keen-slider/react";
 import Arrow from "./CarouselArrow";
 import Countdown from "./Countdown";
+import NftCard from "../UI/NftCard";
 
 const NewItems = ({data, items}) => {
 
@@ -51,59 +52,7 @@ const NewItems = ({data, items}) => {
           >
           {data?.map((item, index) => (
             item ? (
-            <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide" key={item.id}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  <Link
-                    to={`/author/${item.authorId}`}
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="Creator: Monica Lucas"
-                  >
-                    <img className="lazy" src={item.authorImage} alt="" />
-                    <i className="fa fa-check"></i>
-                  </Link>
-                </div>
-                <Countdown time={item.expiryDate} />
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      <button>Buy Now</button>
-                      <div className="nft__item_share">
-                        <h4>Share</h4>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="" target="_blank" rel="noreferrer">
-                          <i className="fa fa-twitter fa-lg"></i>
-                        </a>
-                        <a href="">
-                          <i className="fa fa-envelope fa-lg"></i>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <img
-                      src={item.nftImage}
-                      className="lazy nft__item_preview"
-                      alt={item.title}
-                    />
-                  </Link>
-                </div>
-                <div className="nft__item_info">
-                  <Link to={`/item-details/${item.nftId}`}>
-                    <h4>{item.title}</h4>
-                  </Link>
-                  <div className="nft__item_price">{item.price + ' '}ETH</div>
-                  <div className="nft__item_like">
-                    <i id={`likeButton${index}`} className="fa fa-heart" onClick={() => handleLikes(index)} />
-                    <span>{(likedArray.some(value => value === index)) ? (item.likes + 1) : (item.likes)}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <NftCard item={item} index={index} likedArray={likedArray} handleLikes={handleLikes} />
             ) : (
               <div id="carousel-div" className="col-lg-3 col-md-6 col-sm-6 col-xs-12 keen-slider__slide skeleton-wrapper" key={item.id}>
               <div className="nft__item">

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Link } from "react-router-dom";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 
-const TopSellers = () => {
+const TopSellers = ({data}) => {
+  const fallback = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
   return (
     <section id="section-popular" className="pb-5">
       <div className="container">
@@ -15,24 +16,43 @@ const TopSellers = () => {
           </div>
           <div className="col-md-12">
             <ol className="author_list">
-              {new Array(12).fill(0).map((_, index) => (
-                <li key={index}>
-                  <div className="author_list_pp">
-                    <Link to="/author">
-                      <img
-                        className="lazy pp-author"
-                        src={AuthorImage}
-                        alt=""
-                      />
-                      <i className="fa fa-check"></i>
-                    </Link>
-                  </div>
-                  <div className="author_list_info">
-                    <Link to="/author">Monica Lucas</Link>
-                    <span>2.1 ETH</span>
-                  </div>
-                </li>
-              ))}
+              { data ? (
+                data?.map((item, index) => (
+                  <li key={item.id}>
+                    <div className="author_list_pp">
+                      <Link to={`/author/${item.authorId}`}>
+                        <img
+                          className="lazy pp-author"
+                          src={item.authorImage}
+                          alt=""
+                        />
+                        <i className="fa fa-check"></i>
+                      </Link>
+                    </div>
+                    <div className="author_list_info">
+                      <Link to="/author">{item.authorName}</Link>
+                      <span>{item.price + ' ETH'}</span>
+                    </div>
+                  </li>
+                    )
+                  )
+                ) : (
+                  fallback.map((_, index) => {
+                    return( 
+                  <li key={index}>
+                    <div className="author_list_pp skeleton-auth skeleton-auth-top">
+                        <div
+                          className="lazy skeleton-box"
+                        />
+                    </div>
+                    <div className="author_list_info skeleton-auth-info">
+                      <div className="skeleton-box skeleton-name-top"> </div>
+                      <span className="skeleton-box skeleton-price-top"> </span>
+                      <span className="skeleton-label-top">{' ETH '}</span>
+                    </div>
+                  </li>
+                )}))
+              }
             </ol>
           </div>
         </div>

--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -30,7 +30,7 @@ const TopSellers = ({data}) => {
                       </Link>
                     </div>
                     <div className="author_list_info">
-                      <Link to="/author">{item.authorName}</Link>
+                      <Link to={`/author/${item.authorId}`}>{item.authorName}</Link>
                       <span>{item.price + ' ETH'}</span>
                     </div>
                   </li>

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16841,3 +16841,8 @@ img {
   top: 75%;
 }
 
+.skeleton-info-adjust {
+  display: flex;
+  justify-content: end;
+  margin-right: 4px;
+}

--- a/src/css/styles/style.css
+++ b/src/css/styles/style.css
@@ -16813,3 +16813,31 @@ img {
 .user-liked {
   color: #ea3943;
 }
+
+.skeleton-auth-top {
+  height: 3rem;
+  width: 3rem;
+  top: 0%;
+  left: 0rem;
+  transform: translateY(-10%);
+}
+
+.skeleton-auth-info {
+  position: relative;
+  height: 2rem;
+  width: 100%;
+}
+
+.skeleton-name-top {
+  position: absolute;
+  height: 1rem;
+  width: 50%;
+}
+
+.skeleton-price-top {
+  position: absolute;
+  height: 1rem;
+  width: 25%;
+  top: 75%;
+}
+

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,11 +1,9 @@
-import React, { useEffect } from "react";
+import React from "react";
 import SubHeader from "../images/subheader.jpg";
 import ExploreItems from "../components/explore/ExploreItems";
 
 const Explore = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
+  
 
   return (
     <div id="wrapper">
@@ -32,7 +30,7 @@ const Explore = () => {
         <section aria-label="section">
           <div className="container">
             <div className="row">
-              <ExploreItems />
+              <ExploreItems/>
             </div>
           </div>
         </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,6 +12,7 @@ import { debounce } from "lodash";
 const Home = () => {
   const [hotCollectionsArray, setHotCollectionsArray] = useState();
   const [newItemsArray, setNewItemsArray] = useState();
+  const [topSellersArray, setTopSellersArray] = useState();
   const [shownItems, setShownItems] = useState(4)
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -34,6 +35,8 @@ const Home = () => {
         setHotCollectionsArray(hotCollectionsData.data)
         const newItemsData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/newItems')
         setNewItemsArray(newItemsData.data)
+        const topSellersData = await axios.get('https://us-central1-nft-cloud-functions.cloudfunctions.net/topSellers')
+        setTopSellersArray(topSellersData.data)
       }
       fetchData();
     } catch (error) {
@@ -55,7 +58,7 @@ const Home = () => {
           <HotCollections data={hotCollectionsArray} items={shownItems} />
         }
         <NewItems data={newItemsArray} items={shownItems} />
-        <TopSellers />
+        <TopSellers data={topSellersArray} />
         <BrowseByCategory />
       </div>
     </div>


### PR DESCRIPTION
**Task:**

Introduce Dynamic function to the '/explore' route page
Retrieve API information for page
Display information as a card, similar to the "Hot Collections" section of the home page with skeleton loader
--Modularize this card and its related skeleton for uniformity and ease of use
Enable link functionality on each item's informational elements
Paginate with 8 results on load, 4 additional results per button click
--Remove button when no more results exist to be loaded

**Why:**

(**Because David told me to**)
Allow user to browse the '/explore' page and see all relevant information
Allow user to click on each part of the information to be linked to relevant informational pages
Don't overwhelm the user with too many results on initial load, allowing them to load more as they are ready
Inform user when they have reached the end of the API results by removing the 'Load More' button
Create modularity and reusability within code by extracting Hot Collections card to its own React Component
Do the same by extracting the skeleton loading state for the same component to its own React Component

**How:**

On loading the page, a skeleton loader identical to the Hot Collections page loader is shown for the first 8 items. Once the API request is complete and data is received, the skeleton loaders are replaced with uniform cards containing the retrieved information. At this stage only the first 8 are shown, the user is then able to load more in 4 item packets until all are loaded by clicking a "Load More" button; this button is removed when there is no more data to load. Each element of the items is able to be clicked by the user to navigate to a different page relevant to that information so long as the element has a related page.

For modularity and reusability within the code, the Hot Components info card and a related Skeleton Loading State have been removed from their respective page and placed into their own React Functional Component. This allows the Hot Components info card to be reused on the Explore page, giving the two pages visual similarity and relationship. Likewise, the optional feature for the user to like each NFT personally and increase the likes number related to it has been moved to work on the Explore page with full like/unlike function as it's a simple function, but adds a good bit to user experience.


![Screenshot 11](https://github.com/user-attachments/assets/7b630346-8e4b-43c9-8797-00854be4fdd4)
![Screenshot 12](https://github.com/user-attachments/assets/54c42e00-777d-4de2-934e-aae06973e188)
![Screenshot 14](https://github.com/user-attachments/assets/f77a2755-705e-4e89-b819-c3fc7e67cf0d)
![Screenshot 15](https://github.com/user-attachments/assets/f4c97db5-895d-411a-b770-6c9f3b7e9339)
![Screenshot 16](https://github.com/user-attachments/assets/59292cc4-5123-408f-b4a9-7e8b062266c4)
![Screenshot 17](https://github.com/user-attachments/assets/47719ece-4162-498f-8bc5-a12b68769e78)
![Screenshot 18](https://github.com/user-attachments/assets/6f5d1f0a-69f4-4b21-986a-389551508569)
![Screenshot 19](https://github.com/user-attachments/assets/cbb453a4-c1bc-4f2d-a3a9-7135314ec06b)
![Screenshot 20](https://github.com/user-attachments/assets/1aaa9030-dbcc-47c5-acd0-444c29b5af36)
![Screenshot 21](https://github.com/user-attachments/assets/34c24b99-b822-4964-9dc2-d63e30bc87a7)
