### PR TITLE
update animations on top-sellers

### DIFF
--- a/src/components/home/TopSellers.jsx
+++ b/src/components/home/TopSellers.jsx
@@ -20,7 +20,7 @@ const TopSellers = ({data}) => {
             <ol className="author_list">
               { data ? (
                 data?.map((item, index) => (
-                  <li key={item.id} data-aos='fade-up' data-aos-delay={100 * index}>
+                  <li key={item.id} data-aos='fade-up' data-aos-delay={250 * ((index % 3) / 1)} data-aos-offset={-300 * ((index % 3) / 1)}>
                     <div className="author_list_pp">
                       <Link to={`/author/${item.authorId}`}>
                         <img


### PR DESCRIPTION
Task:

Fix broken repository link in git bash
Modify animation timings and trigger points for TopSellers component

Why:

Can't fix anything if i can't pull
Smoothen out animations so user has a more pleasant experience

How:

By leveraging modulo operations, numerical inversions, and the unique indexing order of the TopSellers component, I was able to make it so that each line horizontally animates in together, despite their indices being separated by 2 on every step. To do this, I took the step time I wanted each part of the animation to take and multiplied that by the equation (i % 3) / 1, where i is the index of the element being animated. This allows for indexes 0, 3, 6, and 9 to animate together, as well as 1, 4, 7, and 10, and the group 2, 5, 8, and 11 last. Utilizing this logic, the items seem to slide up the page into their resting place uniformly and smoothly.